### PR TITLE
Increase array depth of NormalizedConfigurationParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.1
+
+- Increased allowed array depth of `NormalizedConfigurationParameters` by one level. This only affects the Psalm type and is not validated at runtime.
+
 ## 2.0.0
 
 - **[Breaking change](./UPGRADE.md#dropped-interface-suffix-from-interfaces)**: Dropped `*Interface` suffix from interfaces.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reduced cost of change through CQS in Symfony
 
-[![Latest Stable Version](https://img.shields.io/badge/stable-2.0.0-blue)](https://packagist.org/packages/digital-craftsman/cqs-routing)
+[![Latest Stable Version](https://img.shields.io/badge/stable-2.0.1-blue)](https://packagist.org/packages/digital-craftsman/cqs-routing)
 [![PHP Version Require](https://img.shields.io/badge/php-8.4-5b5d95)](https://packagist.org/packages/digital-craftsman/cqs-routing)
 [![codecov](https://codecov.io/gh/digital-craftsman-de/cqs-routing/branch/main/graph/badge.svg?token=YUKRDW1L8G)](https://codecov.io/gh/digital-craftsman-de/cqs-routing)
 ![Packagist Downloads](https://img.shields.io/packagist/dt/digital-craftsman/cqs-routing)

--- a/src/Routing/RoutePayload.php
+++ b/src/Routing/RoutePayload.php
@@ -20,7 +20,7 @@ use DigitalCraftsman\CQSRouting\ResponseConstructor\ResponseConstructor;
  * The symfony routing does not support the usage of objects as it has to dump them into a php file for caching. Therefore, we create an
  * object and convert into and from an array. The validation is done through the RouteBuilder at build time (cache warmup).
  *
- * @psalm-type NormalizedConfigurationParameters = scalar|array<array-key, scalar|array<array-key, scalar|null>|null>|null
+ * @psalm-type NormalizedConfigurationParameters = scalar|array<array-key, scalar|array<array-key, scalar|array<array-key, scalar|null>|null>|null>|null
  */
 final readonly class RoutePayload
 {


### PR DESCRIPTION
## Changes

- Increased allowed array depth of `NormalizedConfigurationParameters` by one level. This only affects the Psalm type and is not validated at runtime.